### PR TITLE
adds missing vArg reference to isArray check

### DIFF
--- a/src/microplugin.js
+++ b/src/microplugin.js
@@ -126,7 +126,7 @@
 	};
 
 	var utils = {
-		isArray: Array.isArray || function() {
+		isArray: Array.isArray || function(vArg) {
 			return Object.prototype.toString.call(vArg) === '[object Array]';
 		}
 	};


### PR DESCRIPTION
Before I saw that I had to add the es5 compatibility for ie8, this was throwing an error. 
