### PR TITLE
Updated `initializePlugins` to not wipe out previous `plugins` data

### DIFF
--- a/src/microplugin.js
+++ b/src/microplugin.js
@@ -48,7 +48,7 @@
 			var self  = this;
 			var queue = [];
 
-			self.plugins = {
+			self.plugins = self.plugins || {
 				names     : [],
 				settings  : {},
 				requested : {},

--- a/test/index.js
+++ b/test/index.js
@@ -169,6 +169,23 @@ describe('MicroPlugin', function() {
 
 		});
 
+		it('should not overwrite `plugins` data from previous initializations', function() {
+			var Lib = function() {
+				this.initializePlugins({'a': {test: 'hello_a'}});
+				this.initializePlugins(['b']);
+			};
+			MicroPlugin.mixin(Lib);
+
+			Lib.define('a', function () { });
+			Lib.define('b', function () { });
+
+			var instance = new Lib();
+			assert(instance.plugins.names.indexOf('a') >= 0);
+			assert.deepEqual(instance.plugins.settings['a'], {test: 'hello_a'});
+			assert(instance.plugins.requested['a']);
+			assert(instance.plugins.loaded.hasOwnProperty('a'));
+		});
+
 	});
 
 	describe('#require()', function() {


### PR DESCRIPTION
Hey Brian,

I noticed today that calling `initializePlugins` multiple times would end up loading/executing all plugins, but would wipe out the `plugins` object on each invocation.

I was working on creating a plugin for Selectize that would add "singlePlugins" and "multiPlugins" settings, so that I could define default plugins more simply, when I ran into this issue. My custom "mode_plugins" plugin calls `initializePlugins` after Selectize has already initialized it and other plugins.

The main issue this causes in Selectize is that CSS classes are only applied for the latter round of plugins (single/multi), and not for the original listing of plugins, because Selectize looks at `self.plugins.names` to generate the classes.

This pull request includes a simple fix/test for Microplugin to ensure that all plugin data stays intact across multiple invocations of `initializePlugins`. One thing this fix potentially leaves the door open for is that `self.plugins` could already exist, but not be in the format that Microplugin expects. I wouldn't expect this to be an issue in practice, however.
